### PR TITLE
Fix expand icon transform degree

### DIFF
--- a/src/components/metainfos/ObjectGraphDefNodeViewer.js
+++ b/src/components/metainfos/ObjectGraphDefNodeViewer.js
@@ -33,12 +33,12 @@ export default function ObjectGraphDefNodeViewer({ nodesList }) {
 
 const useNodeTableRowStyle = makeStyles((theme) => ({
   expand: {
-    transform: "rotate(180deg)",
+    transform: "rotate(0deg)",
     marginLeft: "auto",
     transition: theme.transitions.create("transform", { duration: theme.transitions.duration.shortest }),
   },
   expandOpen: {
-    transform: "rotate(0deg)",
+    transform: "rotate(180deg)",
   },
   button: {
     padding: 0,


### PR DESCRIPTION
## Details

* Fix the transform rotation of the expand button of `ObjectGraphDefNodeViewer`.
  * Should be `0deg` when not expanded, and `180deg` when expanded.

## Before

<img width="877" alt="스크린샷 2021-08-21 오후 11 31 59" src="https://user-images.githubusercontent.com/5152494/130325107-72810721-4f51-41f4-ba03-7474fb2ea79c.png">

## After

<img width="880" alt="스크린샷 2021-08-21 오후 11 32 08" src="https://user-images.githubusercontent.com/5152494/130325111-4e35c1d9-ae75-4139-8a67-97b19ca9f916.png">
